### PR TITLE
Only create "related items" for new packages

### DIFF
--- a/ckanext/stadtzhharvest/harvester.py
+++ b/ckanext/stadtzhharvest/harvester.py
@@ -185,8 +185,11 @@ class StadtzhHarvester(HarvesterBase):
         package = model.Package.get(package_dict['id'])
         if not package or self._import_updated_packages():
             result = self._create_or_update_package(package_dict, harvest_object)
-            self._related_create_or_update(package_dict['name'], package_dict['related'])
             log.debug('Dataset `%s` has been added or updated' % package_dict['id'])
+
+        # Update "Related items" only the first time, do not update via harvester
+        if not package:
+            self._related_create_or_update(package_dict['name'], package_dict['related'])
 
         if package:
             # package has already been imported.


### PR DESCRIPTION
Realted items often contain links and markup which is not available in
the meta.xml and is therefore changed after the initial import on the
CKAN system. To not lose these changes, this information should not be
touched again by the harvester after the initial import.

Maybe in a later version the markup information can be included in the
meta.xml and this decision might be revised, but for now we simply do
not change the related items if the package already exists.