### PR TITLE
munge title to name

### DIFF
--- a/ckanext/stadtzhharvest/harvester.py
+++ b/ckanext/stadtzhharvest/harvester.py
@@ -275,10 +275,7 @@ class StadtzhHarvester(HarvesterBase):
             group_titles = categories.split(', ')
             groups = []
             for title in group_titles:
-                if title == u'Bauen und Wohnen':
-                    name = u'bauen-wohnen'
-                else:
-                    name = title.lower().replace(u'ö', u'oe').replace(u'ä', u'ae')
+                name = munge_title_to_name(title)
                 groups.append((name, title))
             return self._get_group_ids(groups)
         else:


### PR DESCRIPTION
instead of dealing with 'Bauen und Wohnen' in a special way, function munge_title_to_name will always be used and create a valid name, also dealing with umlauts.
Therefore group Bauen und Wohnen will now have the title bauen-und-wohnen instead of bauen-wohnen