### PR TITLE
use md5-hash for compatibility with ckanext-xloader

### DIFF
--- a/ckanext/stadtzhharvest/harvester.py
+++ b/ckanext/stadtzhharvest/harvester.py
@@ -624,7 +624,7 @@ class StadtzhHarvester(HarvesterBase):
                         if link.find('url').text != "" and link.find('url').text is not None:
                             # generate hash for URL
                             url = link.find('url').text
-                            sha1 = hashlib.sha1()
+                            sha1 = hashlib.md5()
                             sha1.update(url)
                             resources.append({
                                 'url': url,
@@ -645,7 +645,7 @@ class StadtzhHarvester(HarvesterBase):
                     if include_files:
 			# calculate the SHA1 hash of this file
                         BUF_SIZE = 65536  # lets read stuff in 64kb chunks!
-                        sha1 = hashlib.sha1()
+                        sha1 = hashlib.md5()
                         with retry_open_file(resource_path, 'rb') as f:
                             while True:
                                 data = f.read(BUF_SIZE)


### PR DESCRIPTION
The Plugin ckanext-xloader uses an md5-hash to check whether a resource’s content has changed or not.
Our plugin relies on the hash as well. To prevent overriding each other’s hashes inbetween the plugins, we need to use the same algorithms.