### PR TITLE
Munge tags and test tags and groups

### DIFF
--- a/ckanext/stadtzhharvest/harvester.py
+++ b/ckanext/stadtzhharvest/harvester.py
@@ -19,7 +19,7 @@ from ckan.logic import get_action, NotFound
 import ckan.plugins.toolkit as tk
 from ckan import plugins as p
 from ckan.lib.helpers import json
-from ckan.lib.munge import munge_title_to_name
+from ckan.lib.munge import munge_title_to_name, munge_tag
 from ckanext.harvest.harvesters import HarvesterBase
 from ckanext.harvest.model import HarvestObject
 from ckanext.stadtzhtheme.plugin import StadtzhThemePlugin
@@ -786,7 +786,7 @@ class StadtzhHarvester(HarvesterBase):
         tags_node = dataset_node.find('schlagworte')
         if tags_node is not None and tags_node.text:
             for tag in tags_node.text.split(', '):
-                tags.append({'name': tag})
+                tags.append({'name': munge_tag(tag)})
         log.debug('Added tags: %s' % str(tags))
         return tags
 

--- a/ckanext/stadtzhharvest/tests/fixtures/DWH/nachnamen_2014/meta.xml
+++ b/ckanext/stadtzhharvest/tests/fixtures/DWH/nachnamen_2014/meta.xml
@@ -3,7 +3,7 @@
 	<datensatz>
 		<titel>Test Nachnamen in der Stadt Zürich</titel>
 		<beschreibung>TEST: Anzahl Personen nach Nachnamen, die mindestens drei Mal vorkommen.</beschreibung>
-		<kategorie>Bevölkerung</kategorie>
+		<kategorie>Tourismus, Freizeit, Bevölkerung</kategorie>
 		<rechtsgrundlage></rechtsgrundlage>
 		<raeumliche_beziehung>Stadt Zürich</raeumliche_beziehung>
 		<lieferant>Statistik Stadt Zürich, Präsidialdepartement</lieferant>
@@ -14,7 +14,7 @@
 		<aktualisierungsdatum>30.10.2014</aktualisierungsdatum>
 		<datentyp>Datenaggregat</datentyp>
 		<aktualisierungsintervall>jährlich</aktualisierungsintervall>
-		<schlagworte>sachdaten, tabellen</schlagworte>
+		<schlagworte>sachdaten, tabellen, tag mit spaces, GROSS-klein, umlaute-äüö</schlagworte>
 		<aktuelle_version>1.0</aktuelle_version>
 		<bemerkungen>
 			<bemerkung>

--- a/ckanext/stadtzhharvest/tests/test_harvester.py
+++ b/ckanext/stadtzhharvest/tests/test_harvester.py
@@ -188,6 +188,54 @@ class TestStadtzhHarvester(h.FunctionalTestBase):
         eq_(anzahl[0], u'Gezählte Velofahrten')
         eq_(anzahl[1], u'Anzahl Velos pro Stunde an der jeweiligen Messstelle')
 
+    def test_load_metadata_groups_and_tags(self):
+        harvester = plugin.StadtzhHarvester()
+        dataset_folder = 'nachnamen_2014'
+        data_path = os.path.join(
+            __location__,
+            'fixtures',
+            'DWH'
+        )
+
+        test_meta_xml_path = os.path.join(
+            data_path,
+            dataset_folder,
+            'meta.xml'
+        )
+
+        metadata = harvester._load_metadata_from_path(
+            test_meta_xml_path,
+            dataset_folder,
+            dataset_folder
+        )
+        eq_(metadata['datasetFolder'], dataset_folder)
+        eq_(metadata['datasetID'], dataset_folder)
+
+        # tags
+        eq_(len(metadata['tags']), 5)
+        eq_(
+            metadata['tags'],
+            [
+                    {'name': 'sachdaten'},
+                    {'name': 'tabellen'},
+                    {'name': 'tag-mit-spaces'},
+                    {'name': 'gross-klein'},
+                    {'name': 'umlaute-auo'},
+            ]
+        )
+        
+        # groups
+        def check_group(id, name, title):
+            group_result = h.call_action('group_show', {}, id=id)
+            eq_(group_result['id'], id)
+            eq_(group_result['name'], name)
+            eq_(group_result['title'], title)
+        
+        eq_(len(metadata['groups']), 3)
+        check_group(metadata['groups'][0]['name'], 'tourismus', u'Tourismus')
+        check_group(metadata['groups'][1]['name'], 'freizeit', u'Freizeit')
+        check_group(metadata['groups'][2]['name'], 'bevolkerung', u'Bevölkerung')
+        
 
 class FunctionalHarvestTest(object):
     @classmethod


### PR DESCRIPTION
We can no longer rely on getting "nice" tags, so we need to sanitize them before adding them to CKAN. The easiest way to do that is to use the existing `munge_tag` function.

This PR also adds a test for this new functionality and tests if groups from the meta.xml are applied correctly.