### PR TITLE
Fix UnboundLocalError

### DIFF
--- a/ckanext/stadtzhharvest/harvester.py
+++ b/ckanext/stadtzhharvest/harvester.py
@@ -45,6 +45,7 @@ def retry_open_file(path, mode, tries=10, close=True):
     open file handle
     """
     error = None
+    the_file = None
     while tries:
         try:
             the_file = open(path, mode)
@@ -58,7 +59,7 @@ def retry_open_file(path, mode, tries=10, close=True):
         else:
             break
     if not tries:
-        if not the_file.closed:
+        if the_file and not the_file.closed:
             the_file.close()
         raise error
     yield the_file


### PR DESCRIPTION
 If the retry logic kicks in all tries are used, then there is currently an UnboundLocalError: 

"harvester.py", line 61, in retry_open_file if not the_file.closed: UnboundLocalError: local variable 'the_file' referenced before assignment