### PR TITLE
Add six and future to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 defusedxml==0.5.0
 ckantoolkit==0.0.3
+# Required so that ckanext-xloader v0.7.0 works (Python 3 compatibility)
+six==1.12.0
+future==0.18.2


### PR DESCRIPTION
These are necessary now that we are using v0.7.0 of ckanext-xloader, which has been adapted for Python 3 as well as 2.