### PR TITLE
Update for CKAN 2.9

### DIFF
--- a/ckanext/stadtzhharvest/harvester.py
+++ b/ckanext/stadtzhharvest/harvester.py
@@ -904,7 +904,7 @@ class StadtzhHarvester(HarvesterBase):
                 if resource_file:
                     resource_dict = {
                         'name': resource_file,
-                        'url': resource_file,
+                        'url': '',
                         'url_type': 'upload',
                         'format': resource_file.split('.')[-1],
                         'resource_type': 'file'

--- a/test.ini
+++ b/test.ini
@@ -14,10 +14,10 @@ use = config:../ckan/test-core.ini
 solr_url = http://127.0.0.1:8983/solr
 ckan.plugins = stats synchronous_search stadtzhtheme harvest ckan_harvester stadtzh_harvester dcat text_view recline_view image_view
 
-ckanext.stadtzh-theme.descr_file = ./ckanext/stadtzhtheme/descr.yaml
-ckanext.stadtzh-theme.upload_user = apache
-ckanext.stadtzh-theme.upload_group = ckan
-ckanext.stadtzh-theme.dcat_ap_organization_slug = stadt-zurich
+ckanext.stadtzhtheme.descr_file = ./ckanext/stadtzhtheme/descr.yaml
+ckanext.stadtzhtheme.upload_user = apache
+ckanext.stadtzhtheme.upload_group = ckan
+ckanext.stadtzhtheme.dcat_ap_organization_slug = stadt-zurich
 ckanext.dcat.rdf.profiles = stadtzh_swiss_dcat
 
 # Internationalization


### PR DESCRIPTION
We are using ckanext-envvars for config now, and env var names cannot contain hyphens.